### PR TITLE
update stream_status

### DIFF
--- a/dipy/direction/closest_peak_direction_getter.pxd
+++ b/dipy/direction/closest_peak_direction_getter.pxd
@@ -26,20 +26,12 @@ cdef class BasePmfDirectionGetter(DirectionGetter):
         self,
         double[::1] point)
 
-    cpdef int generate_streamline(
-            self,
-            double[::1] seed,
-            double[::1] dir,
-            cnp.float_t[:, :] streamline,
-            StreamlineStatus stream_status
-            ) except -1
+    cpdef tuple generate_streamline(self,
+                                                      double[::1] seed,
+                                                      double[::1] dir,
+                                                      cnp.float_t[:, :] streamline,
+                                                      StreamlineStatus stream_status)
 
-    cdef int generate_streamline_c(
-            self,
-            double* seed,
-            double* dir,
-            cnp.float_t[:, :] streamline,
-            StreamlineStatus* stream_status)
 
     cdef _get_pmf(
         self,

--- a/dipy/direction/closest_peak_direction_getter.pyx
+++ b/dipy/direction/closest_peak_direction_getter.pyx
@@ -162,12 +162,12 @@ cdef class BasePmfDirectionGetter(DirectionGetter):
         self.step_size = step_size
         self.use_fixed_step = fixedstep
 
-    cdef int generate_streamline_c(self,
-                                   double* seed,
-                                   double* dir,
-                                   cnp.float_t[:, :] streamline,
-                                   StreamlineStatus* stream_status
-                                   ):
+    cpdef tuple generate_streamline(self,
+                                    double[::1] seed,
+                                    double[::1] dir,
+                                    cnp.float_t[:, :] streamline,
+                                    StreamlineStatus stream_status
+                                    ):
        cdef:
            cnp.npy_intp i
            cnp.npy_intp len_streamlines = streamline.shape[0]
@@ -180,28 +180,28 @@ cdef class BasePmfDirectionGetter(DirectionGetter):
        else:
            step = step_to_boundary
 
-       copy_point(seed, point)
-       copy_point(seed, &streamline[0,0])
+       copy_point(&seed[0], point)
+       copy_point(&seed[0], &streamline[0,0])
 
-       stream_status[0] = TRACKPOINT
+       stream_status = TRACKPOINT
        for i in range(1, len_streamlines):
-           if self.get_direction_c(point, dir):
+           if self.get_direction_c(point, &dir[0]):
                break
            for j in range(3):
                voxdir[j] = dir[j] / self.voxel_size #[j]  # update to a list to support non isotropic voxel sizes
            step(point, voxdir, self.step_size)
            copy_point(point, &streamline[i, 0])
-           stream_status[0] = self.stopping_criterion.check_point_c(point)
-           if stream_status[0] == TRACKPOINT:
+           stream_status = self.stopping_criterion.check_point_c(point)
+           if stream_status == TRACKPOINT:
                continue
-           elif (stream_status[0] == ENDPOINT or
-                 stream_status[0] == INVALIDPOINT or
-                 stream_status[0] == OUTSIDEIMAGE):
+           elif (stream_status == ENDPOINT or
+                 stream_status == INVALIDPOINT or
+                 stream_status == OUTSIDEIMAGE):
                break
        else:
            # maximum length of streamline has been reached, return everything
            i = streamline.shape[0]
-       return i
+       return i, stream_status
 
     def _get_peak_directions(self, blob):
         """Gets directions using parameters provided at init.

--- a/dipy/tracking/direction_getter.pxd
+++ b/dipy/tracking/direction_getter.pxd
@@ -9,19 +9,11 @@ cdef class DirectionGetter:
     cpdef cnp.ndarray[cnp.float_t, ndim=2] initial_direction(
         self, double[::1] point)
 
-    cpdef int generate_streamline(
-        self,
-        double[::1] seed,
-        double[::1] dir,
-        cnp.float_t[:, :] streamline,
-        StreamlineStatus stream_status) except -1
-
-    cdef int generate_streamline_c(
-        self,
-        double* seed,
-        double* dir,
-        cnp.float_t[:, :] streamline,
-        StreamlineStatus* stream_status)
+    cpdef tuple generate_streamline(self,
+                                                      double[::1] seed,
+                                                      double[::1] dir,
+                                                      cnp.float_t[:, :] streamline,
+                                                      StreamlineStatus stream_status)
 
 
     cpdef int get_direction(

--- a/dipy/tracking/direction_getter.pyx
+++ b/dipy/tracking/direction_getter.pyx
@@ -10,19 +10,11 @@ cdef class DirectionGetter:
             self, double[::1] point):
         pass
 
-    cpdef int generate_streamline(self,
-                                  double[::1] seed,
-                                  double[::1] dir,
-                                  cnp.float_t[:, :] streamline,
-                                  StreamlineStatus stream_status) except -1:
-
-        return self.generate_streamline_c(&seed[0], &dir[0], streamline, &stream_status)
-
-    cdef int generate_streamline_c(self,
-                                   double* seed,
-                                   double* dir,
-                                   cnp.float_t[:, :] streamline,
-                                   StreamlineStatus* stream_status):
+    cpdef tuple generate_streamline(self,
+                                                      double[::1] seed,
+                                                      double[::1] dir,
+                                                      cnp.float_t[:, :] streamline,
+                                                      StreamlineStatus stream_status):
         pass
 
     cpdef int get_direction(self,

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -129,6 +129,7 @@ def local_tracker(
     cdef:
         cnp.npy_intp i
         StreamlineStatus stream_status
+        StreamlineStatus stream_status_2
         double dir[3]
         double vs[3]
         double seed[3]
@@ -145,13 +146,14 @@ def local_tracker(
 
     ###  BUG HERE ### the stream_status is not correctly returned.
 
-    j = dg.generate_streamline(seed_pos, first_step, streamline, stream_status)
+    j, stream_status_2 = dg.generate_streamline(seed_pos, first_step,
+                                                streamline, stream_status_2)
 
     i = _local_tracker(dg, sc, seed, dir, vs, streamline,
                        step_size, fixedstep, &stream_status)
     if not i == j:
-        print(stream_status1, stream_status)
-    return i, stream_status
+        print(stream_status1, stream_status_2, stream_status)
+    return i, stream_status_2
 
 
 @cython.boundscheck(False)


### PR DESCRIPTION
This quick PR should solve your problem with `stream_status` variable on the `generate_streamline` function

Also, I removed the cdef function which is useless in this case. 

As a reminder,  `def+cdef`  == `cpdef`.  same performance approximately. 

- With inheritance, `cpdef` is slightly faster
- without inheritance `def+cdef` is faster

some useful documentation for you and @guaje:
- https://www.javaer101.com/en/article/18562614.html
- https://stackoverflow.com/questions/48864631/what-are-the-differences-between-a-cpdef-and-a-cdef-wrapped-in-a-def
