### PR TITLE
`get_pmf_value`, fix compiling issue

### DIFF
--- a/dipy/direction/closest_peak_direction_getter.pyx
+++ b/dipy/direction/closest_peak_direction_getter.pyx
@@ -101,7 +101,7 @@ cdef class BasePmfDirectionGetter(DirectionGetter):
             double[:] pmf
             double absolute_pmf_threshold
 
-        pmf = self.pmf_gen.get_pmf_c(point)
+        pmf = self.pmf_gen.get_pmf(<double[:3]>point)
         _len = pmf.shape[0]
 
         absolute_pmf_threshold = self.pmf_threshold*np.max(pmf)

--- a/dipy/direction/pmf.pxd
+++ b/dipy/direction/pmf.pxd
@@ -7,8 +7,7 @@ cdef class PmfGen:
         object sphere
 
     cpdef double[:] get_pmf(self, double[::1] point)
-    cdef double[:] get_pmf_c(self, double* point)
-    cpdef double get_pmf_val(self, double[::1] point, double[::1] xyz)
+    cpdef double get_pmf_value(self, double[::1] point, double[::1] xyz)
     cdef void __clear_pmf(self)
     pass
 

--- a/dipy/direction/tests/test_pmf.py
+++ b/dipy/direction/tests/test_pmf.py
@@ -22,7 +22,7 @@ def test_pmf_val():
         pmf = pmfgen.get_pmf(point)
         # Create a direction vector close to the vertex idx
         xyz = sphere.vertices[idx] + np.random.random([3]) / 100
-        pmf_idx = pmfgen.get_pmf_val(point, xyz)
+        pmf_idx = pmfgen.get_pmf_value(point, xyz)
         # Test that the pmf sampled for the direction xyz is correct
         npt.assert_array_equal(pmf[idx], pmf_idx)
 


### PR DESCRIPTION
Hi @gabknight,

Your PR was not compiling anymore due to a strange renaming (mix between `get_pmf_value`and `get_pmf_val`)

I kept `get_pmf_value` everywhere.

Also, I use the opportunity to remove `cdef get_pmf_c` everywhere and just keep `cpdef get_pmf` as explained before.