### PR TITLE
NF - Pft accepts any directiongetter

### DIFF
--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -394,16 +394,12 @@ class ParticleFilteringTracking(LocalTracking):
             )
 
         self.min_wm_pve_before_stopping = min_wm_pve_before_stopping
-        self.directions = np.empty((maxlen + 1, 3), dtype=float)
         self.pft_max_trial = pft_max_trial
         self.particle_count = particle_count
         self.particle_paths = np.empty(
             (2, self.particle_count, pft_max_steps + 1, 3), dtype=float
         )
         self.particle_weights = np.empty(self.particle_count, dtype=float)
-        self.particle_dirs = np.empty(
-            (2, self.particle_count, pft_max_steps + 1, 3), dtype=float
-        )
         self.particle_steps = np.empty((2, self.particle_count), dtype=np.intp)
         self.particle_stream_statuses = np.empty(
             (2, self.particle_count), dtype=np.intp
@@ -434,14 +430,12 @@ class ParticleFilteringTracking(LocalTracking):
             first_step,
             self._voxel_size,
             streamline,
-            self.directions,
             self.step_size,
             self.pft_max_nbr_back_steps,
             self.pft_max_nbr_front_steps,
             self.pft_max_trial,
             self.particle_count,
             self.particle_paths,
-            self.particle_dirs,
             self.particle_weights,
             self.particle_steps,
             self.particle_stream_statuses,


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the particle filter tracking (PFT) process to remove the use of the `particle_dirs` and `directions` arrays, allowing the algorithm to accept any `DirectionGetter` implementation for direction determination.

### Why are these changes being made?

The removal of the `directions` and `particle_dirs` arrays streamlines PFT by leveraging the direction calculations provided directly by the `DirectionGetter`, reducing redundancy and simplifying the overall code structure. This enhances flexibility, allowing for various `DirectionGetter` strategies to be used without being tied to predefined direction arrays, promoting modularity and code reusability within the dipy tracking framework.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->